### PR TITLE
[16] Add exponential backoff for api.take

### DIFF
--- a/sharded_queue/api.lua
+++ b/sharded_queue/api.lua
@@ -138,7 +138,7 @@ function sharded_tube.take(self, timeout, options)
         if task ~= nil then return task end
 
         if take_timeout < time.nano(wait_part) then
-            take_timeout = 0
+            return nil
         else
             fiber.sleep(wait_part)
             wait_part = wait_part * wait_factor

--- a/sharded_queue/api.lua
+++ b/sharded_queue/api.lua
@@ -41,6 +41,20 @@ local map = function(method, args, uri_list)
     return true, map_data
 end
 
+local function validate_options(options)
+    if not options then return true end
+
+    if options.wait_factor then
+        if type(options.wait_factor) ~= 'number'
+            or options.wait_factor < 1
+        then
+            return false, "wait_factor must be number greater than or equal to 1"
+        end
+    end
+
+    return true
+end
+
 local sharded_tube = {}
 
 function sharded_tube.put(self, data, options)
@@ -334,8 +348,11 @@ function sharded_queue.create_tube(tube_name, options)
         return nil
     end
 
+    local ok , err = validate_options(options)
+    if not ok then error(err) end
+
     tubes[tube_name] = options or {}
-    local ok, err = cartridge.config_patch_clusterwide({ tubes = tubes })
+    ok, err = cartridge.config_patch_clusterwide({ tubes = tubes })
     if not ok then error(err) end
 
     return sharded_queue.tube[tube_name]

--- a/sharded_queue/api.lua
+++ b/sharded_queue/api.lua
@@ -139,10 +139,10 @@ function sharded_tube.take(self, timeout, options)
 
         if take_timeout < time.nano(wait_part) then
             return nil
-        else
-            fiber.sleep(wait_part)
-            wait_part = wait_part * wait_factor
         end
+
+        fiber.sleep(wait_part)
+        wait_part = wait_part * wait_factor
 
         local duration = time.cur() - begin
 

--- a/sharded_queue/time.lua
+++ b/sharded_queue/time.lua
@@ -5,6 +5,7 @@ local time = {}
 time.MAX_TIMEOUT      = 365 * 86400 * 100       -- MAX_TIMEOUT == 100 years
 time.TIMEOUT_INFINITY = 18446744073709551615ULL -- Set to TIMEOUT_INFINITY
 time.MIN_NET_BOX_CALL_TIMEOUT = 1               -- MIN_NET_BOX_CALL_TIMEOUT == 1 second
+time.DEFAULT_WAIT_FACTOR = 2
 
 function time.sec(tm)
     if tm == nil then

--- a/test/take_exp_backoff_test.lua
+++ b/test/take_exp_backoff_test.lua
@@ -26,7 +26,7 @@ local function task_take(tube_name, timeout, channel)
 end
 --
 
-function g.test_default_timeout()
+function g.test_default_wait_factor()
     local tube_name = 'test_default_wait_factor'
     g.queue_conn:call('queue.create_tube', {
         tube_name
@@ -118,7 +118,6 @@ function g.test_timeout()
     local task = channel:get()
 
     t.assert_almost_equals(waiting_time, 1.56, 0.1)
-    -- t.assert_almost_equals(waiting_time, 7, 0.1)
     t.assert_equals(task, nil)
 
     channel:close()

--- a/test/take_exp_backoff_test.lua
+++ b/test/take_exp_backoff_test.lua
@@ -89,36 +89,23 @@ function g.test_success()
     channel:close()
 end
 
-function g.test_timeout()
-    -- start taking
-    -- 0.00 : take fail => wait 0.01 (see wait_part in api.lua)
-    -- 0.01 : take fail => wait 0.05
-    -- 0.06 : take fail => wait 0.25
-    -- 0.31 : take fail => wait 1.25
-    -- 1.56 : take fail => wait 6.25 (next try shoud be after 7.81)
-    -- 7.00 : timeout
+function g.test_invalid_factors()
 
+    local tube_name = 'test_tinvalid_factors'
 
-    local tube_name = 'test_timeout_exp_backoff'
-    g.queue_conn:call('queue.create_tube', {
-        tube_name,
-        {
-            wait_factor = 5,
+    t.assert_error_msg_contains('wait_factor', g.queue_conn.call,
+        g.queue_conn,
+        'queue.create_tube',
+        { tube_name, {
+            wait_factor = 0.5,
         }
     })
 
-    local timeout = 7
-
-    local channel = fiber.channel(2)
-    fiber.create(task_take, tube_name, timeout, channel)
-
-    fiber.sleep(timeout)
-
-    local waiting_time = tonumber(channel:get()) / 1e6
-    local task = channel:get()
-
-    t.assert_almost_equals(waiting_time, 1.56, 0.1)
-    t.assert_equals(task, nil)
-
-    channel:close()
+    t.assert_error_msg_contains('wait_factor', g.queue_conn.call,
+        g.queue_conn,
+        'queue.create_tube',
+        { tube_name, {
+            wait_factor = 'not factor',
+        }
+    })
 end

--- a/test/take_exp_backoff_test.lua
+++ b/test/take_exp_backoff_test.lua
@@ -1,0 +1,115 @@
+local t = require('luatest')
+local g = t.group('exponential_backoff_test')
+
+local log = require('log') -- luacheck: ignore
+
+local config = require('test.helper.config')
+local utils = require('test.helper.utils')
+local fiber = require('fiber')
+
+g.before_all(function()
+    --- Workaround for https://github.com/tarantool/cartridge/issues/462
+    config.cluster:server('queue-router').net_box:close()
+    config.cluster:server('queue-router').net_box = nil
+    config.cluster:server('queue-router'):connect_net_box()
+    g.queue_conn = config.cluster:server('queue-router').net_box
+end)
+
+local function task_take(tube_name, timeout, options, channel)
+    -- fiber function for take task with timeout and calc duration time
+    local start = fiber.time64()
+    local task = g.queue_conn:call(utils.shape_cmd(tube_name, 'take'), { timeout, options })
+    local duration = fiber.time64() - start
+
+    channel:put(duration)
+    channel:put(task)
+end
+--
+
+function g.test_wait_put_taking()
+    local tube_name = 'test_default_wait_factor'
+    g.queue_conn:call('queue.create_tube', {
+        tube_name
+    })
+
+    local timeout = 3 -- second
+
+    local channel = fiber.channel(2)
+    fiber.create(task_take, tube_name, timeout, {}, channel)
+
+    fiber.sleep(timeout / 2)
+    t.assert(g.queue_conn:call(utils.shape_cmd(tube_name, 'put'), { 'simple_task' }, {timeout=1}))
+
+    local waiting_time = tonumber(channel:get()) / 1e6
+    local task = channel:get()
+
+    t.assert_almost_equals(waiting_time, timeout / 2, 0.1)
+    t.assert_equals(task[utils.index.data], 'simple_task')
+
+    channel:close()
+end
+--
+
+function g.test_success()
+    -- start taking
+    -- 0.00 : take fail => wait 0.01 (see wait_part in api.lua)
+    -- 0.01 : take fail => wait 0.05
+    -- 0.06 : take fail => wait 0.25
+    -- 0.31 : take fail => wait 1.25
+    -- 0.35 : put task
+    -- 1.56 : take success
+    -- expected time is 1.56 in case wait_factor = 5
+
+    local tube_name = 'test_success_exp_backoff'
+    g.queue_conn:call('queue.create_tube', {
+        tube_name
+    })
+
+    local timeout = 7
+
+    local channel = fiber.channel(2)
+    fiber.create(task_take, tube_name, timeout, { wait_factor = 5 }, channel)
+
+    fiber.sleep(1)
+    t.assert(g.queue_conn:call(utils.shape_cmd(tube_name, 'put'), { 'simple_task' }, {timeout=1}))
+
+    local waiting_time = tonumber(channel:get()) / 1e6
+    local task = channel:get()
+
+    t.assert_almost_equals(waiting_time, 1.56, 0.1)
+    t.assert_equals(task[utils.index.data], 'simple_task')
+
+    channel:close()
+end
+
+function g.test_timeout()
+    -- start taking
+    -- 0.00 : take fail => wait 0.01 (see wait_part in api.lua)
+    -- 0.01 : take fail => wait 0.05
+    -- 0.06 : take fail => wait 0.25
+    -- 0.31 : take fail => wait 1.25
+    -- 1.56 : take fail => wait 6.25 (next try shoud be after 7.81)
+    -- 7.00 : timeout
+
+
+    local tube_name = 'test_timeout_exp_backoff'
+    g.queue_conn:call('queue.create_tube', {
+        tube_name
+    })
+
+    local timeout = 7
+
+    local channel = fiber.channel(2)
+    fiber.create(task_take, tube_name, timeout, { wait_factor = 5 }, channel)
+
+    fiber.sleep(timeout)
+
+    local waiting_time = tonumber(channel:get()) / 1e6
+    local task = channel:get()
+
+    t.assert_almost_equals(waiting_time, 1.56, 0.1)
+    -- t.assert_almost_equals(waiting_time, 7, 0.1)
+    t.assert_equals(task, nil)
+
+    channel:close()
+end

--- a/test/timeout_test.lua
+++ b/test/timeout_test.lua
@@ -32,7 +32,10 @@ function g.test_try_waiting()
 
     local tube_name = 'try_waiting_test'
     g.queue_conn:call('queue.create_tube', {
-        tube_name
+        tube_name,
+        {
+            wait_factor = 1,
+        }
     })
 
     local timeout = 3 -- second
@@ -45,7 +48,7 @@ function g.test_try_waiting()
     local waiting_time = tonumber(channel:get()) / 1e6
     local task = channel:get()
 
-    t.assert(waiting_time <= 3)
+    t.assert_almost_equals(waiting_time, 3, 0.1)
     t.assert_equals(task, nil)
 
     channel:close()

--- a/test/timeout_test.lua
+++ b/test/timeout_test.lua
@@ -30,8 +30,6 @@ function g.test_try_waiting()
     -- TAKE task with timeout
     -- CHECK uptime and value - nil
 
-    t.skip_if(true, "See 'g.test_timeout' in test/take_exp_backoff.lua")
-
     local tube_name = 'try_waiting_test'
     g.queue_conn:call('queue.create_tube', {
         tube_name
@@ -47,7 +45,7 @@ function g.test_try_waiting()
     local waiting_time = tonumber(channel:get()) / 1e6
     local task = channel:get()
 
-    t.assert_almost_equals(waiting_time, 3, 0.1)
+    t.assert(waiting_time <= 3)
     t.assert_equals(task, nil)
 
     channel:close()
@@ -60,11 +58,12 @@ function g.test_wait_put_taking()
     -- PUT task to tube
     -- CHEK what was taken successfully
 
-    t.skip_if(true, "See 'g.test_default_timeout' in test/take_exp_backoff.lua")
-
     local tube_name = 'wait_put_taking_test'
     g.queue_conn:call('queue.create_tube', {
-        tube_name
+        tube_name,
+        {
+            wait_factor = 1,
+        }
     })
 
     local timeout = 3

--- a/test/timeout_test.lua
+++ b/test/timeout_test.lua
@@ -30,6 +30,8 @@ function g.test_try_waiting()
     -- TAKE task with timeout
     -- CHECK uptime and value - nil
 
+    t.skip_if(true, "See 'g.test_timeout' in test/take_exp_backoff.lua")
+
     local tube_name = 'try_waiting_test'
     g.queue_conn:call('queue.create_tube', {
         tube_name
@@ -57,6 +59,8 @@ function g.test_wait_put_taking()
     -- WAIT timeout value / 2
     -- PUT task to tube
     -- CHEK what was taken successfully
+
+    t.skip_if(true, "See 'g.test_default_timeout' in test/take_exp_backoff.lua")
 
     local tube_name = 'wait_put_taking_test'
     g.queue_conn:call('queue.create_tube', {

--- a/test/ttl_test.lua
+++ b/test/ttl_test.lua
@@ -98,8 +98,12 @@ function g.test_delayed_tasks()
     t.assert_equals(peek_task[utils.index.status], utils.state.DELAYED)
     t.assert_equals(g.queue_conn:call(utils.shape_cmd(tube_name, 'take'), { 0.001 }), nil)
 
+    -- delayed task was not taken
+    fiber.sleep(0.5)
+    t.assert_equals(g.queue_conn:call(utils.shape_cmd(tube_name, 'take'), { 0.01 }), nil)
+
     -- delayed task was taken after timeout
-    local taken_task = g.queue_conn:call(utils.shape_cmd(tube_name, 'take'), { 1.1 })
+    local taken_task = g.queue_conn:call(utils.shape_cmd(tube_name, 'take'), { 0.5 })
     t.assert_equals(taken_task[utils.index.data], 'simple data')
 
     peek_task = g.queue_conn:call(utils.shape_cmd(tube_name, 'peek'), {

--- a/test/ttl_test.lua
+++ b/test/ttl_test.lua
@@ -23,7 +23,7 @@ end
 
 function g.test_fifottl_config()
     local tube_name = 'test_fifottl_config'
-    local tube_options = { ttl = 43, ttr = 15, priority = 17 }
+    local tube_options = { ttl = 43, ttr = 15, priority = 17, wait_factor = 1 }
     g.queue_conn:call('queue.create_tube', {
         tube_name,
         tube_options
@@ -43,7 +43,10 @@ end
 function g.test_touch_task()
     local tube_name = 'touch_task_test'
     g.queue_conn:call('queue.create_tube', {
-        tube_name
+        tube_name,
+        {
+            wait_factor = 1,
+        }
     })
 
     local task = g.queue_conn:call(utils.shape_cmd(tube_name, 'put'), {
@@ -76,7 +79,10 @@ end
 function g.test_delayed_tasks()
     local tube_name = 'delayed_tasks_test'
     g.queue_conn:call('queue.create_tube', {
-        tube_name
+        tube_name,
+        {
+            wait_factor = 1,
+        }
     })
     -- task delayed for 0.1 sec
     local task = g.queue_conn:call(utils.shape_cmd(tube_name, 'put'), {

--- a/test/ttl_test.lua
+++ b/test/ttl_test.lua
@@ -99,7 +99,7 @@ function g.test_delayed_tasks()
     t.assert_equals(g.queue_conn:call(utils.shape_cmd(tube_name, 'take'), { 0.001 }), nil)
 
     -- delayed task was taken after timeout
-    local taken_task = g.queue_conn:call(utils.shape_cmd(tube_name, 'take'), { 1 })
+    local taken_task = g.queue_conn:call(utils.shape_cmd(tube_name, 'take'), { 1.1 })
     t.assert_equals(taken_task[utils.index.data], 'simple data')
 
     peek_task = g.queue_conn:call(utils.shape_cmd(tube_name, 'peek'), {


### PR DESCRIPTION
- add parameter 'wait_factor' to option table
- it stops trying if the next attempt is after timeout