### PR TITLE
Add wait_max option for take

### DIFF
--- a/sharded_queue/api.lua
+++ b/sharded_queue/api.lua
@@ -113,6 +113,7 @@ function sharded_tube.take(self, timeout, options)
 
     local frequency = 1000
     local wait_part = 0.01 -- maximum waiting time in second
+    local wait_max = options.wait_max or self.wait_max or time.MAX_TIMEOUT
 
     local calc_part = time.sec(take_timeout / frequency)
 
@@ -151,7 +152,11 @@ function sharded_tube.take(self, timeout, options)
         end
 
         fiber.sleep(wait_part)
+
         wait_part = wait_part * wait_factor
+        if wait_part > wait_max then
+            wait_part = wait_max
+        end
 
         local duration = time.cur() - begin
 
@@ -458,6 +463,7 @@ local function apply_config(cfg, opts)
             if sharded_queue.tube[tube_name] == nil then
                 local self = setmetatable({
                     tube_name = tube_name,
+                    wait_max = options.wait_max,
                     wait_factor = options.wait_factor or time.DEFAULT_WAIT_FACTOR,
                     log_request = utils.normalize.log_request(options.log_request),
                 }, {

--- a/sharded_queue/utils.lua
+++ b/sharded_queue/utils.lua
@@ -37,4 +37,13 @@ function utils.normalize.log_request(log_request)
     return log_request or false
 end
 
+function utils.normalize.wait_max(wait_max)
+    if wait_max ~= nil then
+        if type(wait_max) ~= 'number' or wait_max <= 0 then
+            return nil, "wait_max must be number greater than 0"
+        end
+    end
+    return wait_max
+end
+
 return utils

--- a/test/take_exp_backoff_test.lua
+++ b/test/take_exp_backoff_test.lua
@@ -15,10 +15,10 @@ g.before_all(function()
     g.queue_conn = config.cluster:server('queue-router').net_box
 end)
 
-local function task_take(tube_name, timeout, channel)
+local function task_take(tube_name, timeout, channel, options)
     -- fiber function for take task with timeout and calc duration time
     local start = fiber.time64()
-    local task = g.queue_conn:call(utils.shape_cmd(tube_name, 'take'), { timeout })
+    local task = g.queue_conn:call(utils.shape_cmd(tube_name, 'take'), { timeout, options })
     local duration = fiber.time64() - start
 
     channel:put(duration)
@@ -108,4 +108,87 @@ function g.test_invalid_factors()
             wait_factor = 'not factor',
         }
     })
+end
+
+function g.test_wait_max_on_tube()
+    -- wait_max = 0.3
+    -- wait_factor = 2 (default value)
+    -- start taking
+    -- 0.00 : take fail => wait 0.01 (see wait_part in api.lua)
+    -- 0.01 : take fail => wait 0.02
+    -- 0.03 : take fail => wait 0.04
+    -- 0.07 : take fail => wait 0.08
+    -- 0.15 : take fail => wait 0.16
+    -- 0.31 : take fail => wait 0.30 (because 0.32 > 0.30)
+    -- 0.61 : take fail => wait 0.30
+    -- ~ 0.80 : put task with ttl = 0.30
+    -- 0.91 : take successful
+    -- expected time is 0.91
+
+    local tube_name = 'test_wait_max_tube'
+    g.queue_conn:call('queue.create_tube', {
+        tube_name,
+        {
+            wait_factor = 2,
+            wait_max = 0.3,
+        }
+    })
+
+    local timeout = 2
+    local channel = fiber.channel(2)
+    fiber.create(task_take, tube_name, timeout, channel)
+
+    fiber.sleep(0.8)
+    t.assert(g.queue_conn:call(utils.shape_cmd(tube_name, 'put'),
+        { 'simple_task' }, {timeout=0.3}))
+
+    local waiting_time = tonumber(channel:get()) / 1e6
+    local task = channel:get()
+
+    t.assert_almost_equals(waiting_time, 0.91, 0.1)
+    t.assert_equals(task[utils.index.data], 'simple_task')
+
+    channel:close()
+end
+
+
+function g.test_wait_max_in_take()
+    -- wait_max = 0.3
+    -- wait_factor = 2 (default value)
+    -- start taking
+    -- 0.00 : take fail => wait 0.01 (see wait_part in api.lua)
+    -- 0.01 : take fail => wait 0.02
+    -- 0.03 : take fail => wait 0.04
+    -- 0.07 : take fail => wait 0.08
+    -- 0.15 : take fail => wait 0.16
+    -- 0.31 : take fail => wait 0.30 (because 0.32 > 0.30)
+    -- 0.61 : take fail => wait 0.30
+    -- ~ 0.80 : put task with ttl = 0.30
+    -- 0.91 : take successful
+    -- expected time is 0.91
+
+    local tube_name = 'test_wait_max_tube'
+    g.queue_conn:call('queue.create_tube', {
+        tube_name,
+        {
+            wait_factor = 2,
+            wait_max = 100,
+        }
+    })
+
+    local timeout = 2
+    local channel = fiber.channel(2)
+    fiber.create(task_take, tube_name, timeout, channel, {wait_max = 0.3})
+
+    fiber.sleep(0.8)
+    t.assert(g.queue_conn:call(utils.shape_cmd(tube_name, 'put'),
+        { 'simple_task' }, {timeout=0.3}))
+
+    local waiting_time = tonumber(channel:get()) / 1e6
+    local task = channel:get()
+
+    t.assert_almost_equals(waiting_time, 0.91, 0.1)
+    t.assert_equals(task[utils.index.data], 'simple_task')
+
+    channel:close()
 end


### PR DESCRIPTION
Close #26 

It is now possible to set a time limit between attempts of the TAKE both in the tube and in the TAKE itself.

Example:
```lua
queue_net_box:call('queue.create_tube', { 'example_tube', {
    wait_factor = 2,  -- the waiting time will increase by 2 times after each failure
    wait_max = 0.3,  -- but it will not exceed this value
}})


task = queue_net_box:call('queue.tube.example_tube.take', { 
    timeout,
    {wait_max = 0.5}  -- This option override wait_max in tube for this TAKE
})
```