### PR TITLE
fix: remove reliance on opts.is_master

### DIFF
--- a/sharded_queue/api.lua
+++ b/sharded_queue/api.lua
@@ -468,13 +468,13 @@ function sharded_queue.create_tube(tube_name, options)
 end
 
 local function init(opts)
-    if opts.is_master then
+    if not box.cfg.read_only then
         rawset(_G, 'queue', sharded_queue)
     end
 end
 
 local function apply_config(cfg, opts)
-    if opts.is_master then
+    if not box.cfg.read_only then
         local cfg_tubes = cfg.tubes or {}
 
         -- try init tubes --

--- a/sharded_queue/storage.lua
+++ b/sharded_queue/storage.lua
@@ -44,7 +44,7 @@ local function validate_config(conf_new, _)
 end
 
 local function apply_config(cfg, opts)
-    if opts.is_master then
+    if not box.cfg.read_only then
         local cfg_tubes = cfg.tubes or {}
 
         local existing_tubes = tubes
@@ -86,7 +86,7 @@ local methods = {
 }
 
 local function init(opts)
-    if opts.is_master then
+    if not box.cfg.read_only then
         statistics.init()
 
         for _, name in pairs(methods) do


### PR DESCRIPTION
Use box.cfg.read_only to decide when to instantiate the queue