### PR TITLE
Fix where tube methods would be missing when new leader is elected

### DIFF
--- a/sharded_queue/storage.lua
+++ b/sharded_queue/storage.lua
@@ -43,8 +43,23 @@ local function validate_config(conf_new, _)
     return true
 end
 
+local methods = {
+    'statistic',
+    'put',
+    'take',
+    'delete',
+    'touch',
+    'ack',
+    'peek',
+    'release',
+    'bury',
+    'kick',
+}
+
 local function apply_config(cfg, opts)
     if opts.is_master then
+        statistics.init()
+
         local cfg_tubes = cfg.tubes or {}
 
         local existing_tubes = tubes
@@ -68,31 +83,11 @@ local function apply_config(cfg, opts)
                 driver.drop(tube_name)
             end
         end
-    end
-    return true
-end
 
-local methods = {
-    'statistic',
-    'put',
-    'take',
-    'delete',
-    'touch',
-    'ack',
-    'peek',
-    'release',
-    'bury',
-    'kick',
-}
-
-local function init(opts)
-    if opts.is_master then
-        statistics.init()
-
+        -- register tube methods --
         for _, name in pairs(methods) do
             local func = function(args)
                 if args == nil then args = {} end
-                local cfg_tubes = cartridge.config_get_readonly('tubes') or {}
                 args.options = cfg_tubes[args.tube_name] or {}
 
                 local tube_name = args.tube_name
@@ -112,6 +107,12 @@ local function init(opts)
         rawset(_G, 'tube_statistic', tube_statistic_func)
         box.schema.func.create('tube_statistic', { if_not_exists = true })
     end
+
+    return true
+end
+
+local function init(opts)
+
 end
 
 return {

--- a/sharded_queue/storage.lua
+++ b/sharded_queue/storage.lua
@@ -122,4 +122,8 @@ return {
     dependencies = {
         'cartridge.roles.vshard-storage',
     },
+
+    __private = {
+        methods = methods,
+    }
 }

--- a/test/api_test.lua
+++ b/test/api_test.lua
@@ -9,7 +9,7 @@ local utils = require('test.helper.utils')
 
 g.before_all(function()
     g.queue_conn = config.cluster:server('queue-router').net_box
-    g.queue_conn_1 = config.cluster:server('queue-router-1').net_box
+    g.queue_conn_ro = config.cluster:server('queue-router-1').net_box
 end)
 
 g.test_exported_api = function()
@@ -52,21 +52,21 @@ g.test_role_statistics = function()
 end
 
 g.test_role_statistics_read_only_router = function()
-    --make sure queue_conn_1 is read_only
-    local ro = g.queue_conn_1:eval("return box.cfg.read_only")
+    --make sure queue_conn_ro is read_only
+    local ro = g.queue_conn_ro:eval("return box.cfg.read_only")
     t.assert_equals(ro, true)
 
     --create queue and put task using read_only router connection
     local tube_name = 'test_tube_read_only_router'
-    g.queue_conn_1:call('queue.create_tube', { tube_name })
+    g.queue_conn_ro:call('queue.create_tube', { tube_name })
 
     local cmd = ("return require('sharded_queue.api').put('%s', 'task_1')"):format(tube_name)
-    local result = g.queue_conn_1:eval(cmd)
+    local result = g.queue_conn_ro:eval(cmd)
     t.assert_equals(result[utils.index.data], 'task_1')
 
     cmd = ("return require('sharded_queue.api').statistics('%s')"):format(tube_name)
     local result_m = g.queue_conn:eval(cmd)
-    local result_ro = g.queue_conn_1:eval(cmd)
+    local result_ro = g.queue_conn_ro:eval(cmd)
 
     t.assert_type(result_m, 'table')
     t.assert_type(result_ro, 'table')

--- a/test/helper/config.lua
+++ b/test/helper/config.lua
@@ -30,8 +30,7 @@ config.cluster = cartridge_helpers.Cluster:new({
                 {
                     instance_uuid = 'aaaaaaaa-aaaa-4000-b000-000000000002',
                     alias = 'queue-router-1',
-                    advertise_port = 3304,
-                    http_port = 8084,
+                    advertise_port = 3302,
                     cluster_cookie = 'sharded-queue-cookie',
                 }
             },
@@ -44,9 +43,14 @@ config.cluster = cartridge_helpers.Cluster:new({
             servers = {
                 {
                     instance_uuid = 'bbbbbbbb-bbbb-4000-b000-000000000001',
-                    alias = 'queue-storage-1',
-                    advertise_port = 3302,
-                    http_port = 8082,
+                    alias = 'queue-storage-1-0',
+                    advertise_port = 3303,
+                    cluster_cookie = 'sharded-queue-cookie',
+                },
+                {
+                    instance_uuid = 'bbbbbbbb-bbbb-4000-b000-000000000002',
+                    alias = 'queue-storage-1-1',
+                    advertise_port = 3304,
                     cluster_cookie = 'sharded-queue-cookie',
                 },
             }
@@ -57,11 +61,16 @@ config.cluster = cartridge_helpers.Cluster:new({
             servers = {
                 {
                     instance_uuid = 'cccccccc-cccc-4000-b000-000000000001',
-                    alias = 'queue-storage-2',
-                    advertise_port = 3303,
-                    http_port = 8083,
+                    alias = 'queue-storage-2-0',
+                    advertise_port = 3305,
                     cluster_cookie = 'sharded-queue-cookie',
-                }
+                },
+                {
+                    instance_uuid = 'cccccccc-cccc-4000-b000-000000000002',
+                    alias = 'queue-storage-2-1',
+                    advertise_port = 3306,
+                    cluster_cookie = 'sharded-queue-cookie',
+                },
             },
         }
     }

--- a/test/storage_test.lua
+++ b/test/storage_test.lua
@@ -1,0 +1,28 @@
+#!/usr/bin/env tarantool
+
+local t = require('luatest')
+local log = require('log')
+local g = t.group('storage')
+
+local storage = require('sharded_queue.storage')
+local config = require('test.helper.config')
+
+
+g.before_all(function()
+    g.storage_master = config.cluster:server('queue-storage-1-0').net_box
+    g.storage_ro = config.cluster:server('queue-storage-1-1').net_box
+end)
+
+g.test_storage_methods = function()
+    --make sure storage_ro is read_only
+    local ro = g.storage_ro:eval("return box.cfg.read_only")
+    t.assert_equals(ro, true)
+
+    for _,method  in pairs(storage.__private.methods) do
+        local global_name = 'tube_' .. method
+        -- Master storage
+       t.assert_equals(g.storage_master:eval(string.format('return box.schema.func.exists("%s")', global_name)), true)
+       --Read Only storage
+       t.assert_equals(g.storage_ro:eval(string.format('return box.schema.func.exists("%s")', global_name)), true)
+    end
+end


### PR DESCRIPTION
Currently the tube methods are registered from the init() method of storage. 

When a new leader is elected, the init() method won't be invoked, and therefore the tube methods would be missing in the new writeable storage instance.

Therefore, the proposed solution is to register the methods through `apply_config` which will be invoked even when leaders are changed. 