### PR TITLE
Ttl support on release and #44 fix

### DIFF
--- a/sharded-queue-scm-1.rockspec
+++ b/sharded-queue-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = 'sharded-queue'
 version = 'scm-1'
 source  = {
-    url = 'git+https://github.com/lkwd/sharded-queue.git';
+    url = 'git+https://github.com/tarantool/sharded-queue.git';
     branch = 'master';
 }
 dependencies = {

--- a/sharded_queue/api.lua
+++ b/sharded_queue/api.lua
@@ -217,17 +217,17 @@ function sharded_tube.release(self, task_id, options)
     local bucket_id, _ = utils.unpack_task_id(task_id, bucket_count)
 
     options = options or {}
+    if options.priority == nil and options.pri ~= nil then
+        options.priority = options.pri
+    end
+    options.task_id = task_id
+    options.tube_name = self.tube_name
+
     options.extra = {
         log_request = utils.normalize.log_request(options.log_request) or self.log_request,
     }
 
-    local task, err = vshard.router.call(bucket_id, 'write', 'tube_release', {
-        {
-            tube_name = self.tube_name,
-            task_id = task_id,
-            options = options,
-        }
-    })
+    local task, err = vshard.router.call(bucket_id, 'write', 'tube_release', {options})
     -- re-raise storage errors
     if err ~= nil then error(err) end
 


### PR DESCRIPTION
This is fix for #44 to prevent tube options get overwrites on 'release' on storage nodes.
Currently we are not supporting options update on 'release'. so it's not going change anything in current  behaviour. 
But it will  help adding #46