### PR TITLE
Prevent tube options overwrites #44

### DIFF
--- a/sharded_queue/drivers/fifottl.lua
+++ b/sharded_queue/drivers/fifottl.lua
@@ -228,12 +228,11 @@ end
 local method = {}
 
 function method.put(args)
-    local delay = args.delay or 0
     -- setup params --
-
-    local ttl = args.ttl or args.options.ttl or time.MAX_TIMEOUT
-    local ttr = args.ttr or args.options.ttr or ttl
-    local priority = args.priority or args.options.priority or 0
+    local delay = args.options.delay or 0
+    local ttl = args.options.ttl or args.default_options.ttl or time.MAX_TIMEOUT
+    local ttr = args.options.ttr or args.default_options.ttr or ttl
+    local priority = args.options.priority or args.default_options.priority or 0
 
     local task = box.atomic(function()
         local idx = get_index(args.tube_name, args.bucket_id)
@@ -267,7 +266,7 @@ function method.put(args)
         }
     end)
 
-    if args.extra and args.extra.log_request then
+    if args.options.extra and args.options.extra.log_request then
         log_operation("put", task)
     end
 

--- a/sharded_queue/storage.lua
+++ b/sharded_queue/storage.lua
@@ -88,7 +88,7 @@ local function apply_config(cfg, opts)
         for _, name in pairs(methods) do
             local func = function(args)
                 if args == nil then args = {} end
-                args.options = cfg_tubes[args.tube_name] or {}
+                args.default_options = cfg_tubes[args.tube_name] or {}
 
                 local tube_name = args.tube_name
                 if tubes[tube_name].method[name] == nil then error(('Method %s not implemented in tube %s'):format(name, tube_name)) end

--- a/test/storage_test.lua
+++ b/test/storage_test.lua
@@ -1,7 +1,6 @@
 #!/usr/bin/env tarantool
 
 local t = require('luatest')
-local log = require('log')
 local g = t.group('storage')
 
 local storage = require('sharded_queue.storage')


### PR DESCRIPTION
This changes will prevent from option overwrites. Also now all the api functions are passing the options in same way.
