### PR TITLE
api: add metrics support 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,13 @@ jobs:
         tarantool:
           - '1.10'
           - '2.8'
+        metrics:
+          - ''
+          - '1.0.0'
         coveralls: [false]
         include:
           - tarantool: '2.11'
+            metrics: '1.0.0'
             coveralls: true
 
     runs-on: ubuntu-20.04
@@ -37,6 +41,11 @@ jobs:
 
       - name: Install requirements
         run: make deps
+
+      - name: Install metrics
+        if: matrix.metrics != ''
+        run: |
+          tarantoolctl rocks install metrics ${{ matrix.metrics }}
 
       - name: Run linter
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,15 @@ build:
 
 .PHONY: deps
 deps:
+	$(TTCTL) rocks install cartridge 2.8.0
 	$(TTCTL) rocks install luacheck 0.26.0
 	$(TTCTL) rocks install luacov 0.13.0
 	$(TTCTL) rocks install luacov-coveralls 0.2.3-1 --server=http://luarocks.org
 	$(TTCTL) rocks install luatest 0.5.7
-	$(TTCTL) rocks install cartridge 2.7.9
+
+.PHONY: deps-full
+deps-full: deps
+	tarantoolctl rocks install metrics 1.0.0
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,16 @@ tubes:
         ttl: 60
      tube_2:
         driver: my_app.my_driver
+     cfg:
+        metrics: false
 ```
+
+Be careful, `cfg` field in a cluster-wide config acts as a configuration
+value for `api.cfg()` call. These configuration options are currently
+supported:
+
+* `metrics` - enable or disable stats collection by metrics.
+  metrics >= 0.11.0 is required. It is enabled by default.
 
 ## Running locally (as an example)
 

--- a/sharded_queue/storage.lua
+++ b/sharded_queue/storage.lua
@@ -21,8 +21,11 @@ local tubes = {}
 local function map_tubes(cfg_tubes)
     local result = {}
     for tube_name, tube_opts in pairs(cfg_tubes) do
-        local driver_name = tube_opts.driver or DEFAULT_DRIVER
-        result[tube_name] = get_driver(driver_name)
+        if tube_name['cfg'] ~= nil or tube_opts.enable == nil then
+            -- do not add 'cfg' as a tube
+            local driver_name = tube_opts.driver or DEFAULT_DRIVER
+            result[tube_name] = get_driver(driver_name)
+        end
     end
     return result
 end

--- a/test/helper/utils.lua
+++ b/test/helper/utils.lua
@@ -38,4 +38,14 @@ function utils.shape_cmd(tube_name, cmd)
     return string.format('queue.tube.%s:%s', tube_name, cmd)
 end
 
+function utils.is_metrics_supported()
+    local is_package, metrics = pcall(require, "metrics")
+    if not is_package then
+        return false
+    end
+    -- metrics >= 0.11.0 is required
+    local counter = require('metrics.collectors.counter')
+    return metrics.unregister_callback and counter.remove and true or false
+end
+
 return utils

--- a/test/metrics_test.lua
+++ b/test/metrics_test.lua
@@ -1,0 +1,137 @@
+local t = require('luatest')
+local g = t.group('metrics_test')
+
+local config = require('test.helper.config')
+local utils = require('test.helper.utils')
+
+g.before_all(function()
+    g.queue_conn = config.cluster:server('queue-router').net_box
+    g.cfg = g.queue_conn:eval("return require('sharded_queue.api').cfg")
+end)
+
+g.before_each(function()
+    t.skip_if(not utils.is_metrics_supported(),
+              "metrics >= 0.11.0 is not installed")
+    g.queue_conn:eval("require('metrics').clear()")
+end)
+
+g.after_each(function()
+    g.queue_conn:eval("require('sharded_queue.api').cfg(...)", {g.cfg})
+end)
+
+local function filter_metrics(metrics, label, value)
+    local filtered = {}
+    for _, v in pairs(metrics) do
+        if v.label_pairs and v.label_pairs[label] and v.label_pairs[label] == value then
+            table.insert(filtered, v)
+        end
+    end
+    return filtered
+end
+
+local function get_metrics(tube_name)
+    local metrics = g.queue_conn:eval([[
+local metrics = require('metrics')
+metrics.invoke_callbacks()
+return metrics.collect()
+]])
+    for _, v in ipairs(metrics) do
+        v.timestamp = nil
+    end
+
+    return filter_metrics(metrics, "name", tube_name)
+end
+
+local function get_metric(metrics, metric_name)
+    local filtered = {}
+    for _, v in pairs(metrics) do
+        if v.metric_name and v.metric_name == metric_name then
+            table.insert(filtered, v)
+        end
+    end
+    return filtered
+end
+
+local function assert_metric(metrics, name, label, values)
+    local metric = get_metric(metrics, name)
+    for k, v in pairs(values) do
+        local filtered = filter_metrics(metric, label, k)
+        t.assert_equals(#filtered, 1, label .. "_" .. k)
+        t.assert_equals(filtered[1].value, v, label .. "_" .. k)
+    end
+end
+
+g.test_metrics = function()
+    local tube_name = 'metrics_test'
+    g.queue_conn:call('queue.create_tube', {
+        tube_name
+    })
+
+    local task_count = 64
+    for i = 1, task_count do
+        g.queue_conn:call(utils.shape_cmd(tube_name, 'put'), {
+            i, { delay = 3 , ttl = 3, ttr = 1}
+        })
+    end
+    -- check all putten task
+    local metrics = get_metrics(tube_name)
+    assert_metric(metrics, "sharded_queue_calls", "status", {
+        done = 0,
+        take = 0,
+        kick = 0,
+        bury = 0,
+        put = task_count,
+        delete = 0,
+        touch = 0,
+        ack = 0,
+        release = 0,
+    })
+    assert_metric(metrics, "sharded_queue_tasks", "status", {
+        ready = 0,
+        taken = 0,
+        done = 0,
+        buried = 0,
+        delayed = task_count,
+        total = task_count,
+    })
+end
+
+g.test_metrics_disabled = function()
+    local tube_name = 'metrics_disabled_test'
+    g.queue_conn:eval("require('sharded_queue.api').cfg(...)",
+        {{metrics = false}})
+
+    g.queue_conn:call('queue.create_tube', {
+        tube_name
+    })
+
+    g.queue_conn:call(utils.shape_cmd(tube_name, 'put'), {
+        1, { delay = 3 , ttl = 3, ttr = 1}
+    })
+    local metrics = get_metrics(tube_name)
+    t.assert_equals(metrics, {})
+end
+
+g.test_metrics_disable = function()
+    local tube_name = 'metrics_disable_test'
+    g.queue_conn:call('queue.create_tube', {
+        tube_name
+    })
+
+    g.queue_conn:call(utils.shape_cmd(tube_name, 'put'), {
+        1, { delay = 3 , ttl = 3, ttr = 1}
+    })
+    local metrics = get_metrics(tube_name)
+    assert_metric(metrics, "sharded_queue_calls", "status", {
+        put = 1,
+    })
+    assert_metric(metrics, "sharded_queue_tasks", "status", {
+        delayed = 1,
+    })
+
+    g.queue_conn:eval("require('sharded_queue.api').cfg(...)",
+        {{metrics = false}})
+
+    metrics = get_metrics(tube_name)
+    t.assert_equals(metrics, {})
+end


### PR DESCRIPTION
The patch adds the ability to export statistics to metrics >= 0.11.0.
sharded_queue does not require the metrics package itself and tries
to use an installed one.

It also adds a new API method api.cfg({options}).

Exported metric values are similar to api.statistics(tube) call:

 * sharded_queue_calls
 * sharded_queue_tasks

Closes https://github.com/tarantool/sharded-queue/issues/55