### PR TITLE
bugfix: fifottl yield every time

### DIFF
--- a/sharded_queue/drivers/fifo.lua
+++ b/sharded_queue/drivers/fifo.lua
@@ -9,13 +9,13 @@ end
 
 local method = {}
 
-local function tube_create(opts)
-    local space_opts = {}
-    local if_not_exists = opts.if_not_exists or true
-    space_opts.temporary = opts.temporary or false
-    space_opts.if_not_exists = if_not_exists
-    space_opts.engine = opts.engine or 'memtx'
-    space_opts.format = {
+local function tube_create(args)
+    local space_options = {}
+    local if_not_exists = args.options.if_not_exists or true
+    space_options.if_not_exists = if_not_exists
+    space_options.temporary = args.options.temporary or false
+    space_options.engine = args.options.engine or 'memtx'
+    space_options.format = {
         { name = 'task_id', type = 'unsigned' },
         { name = 'bucket_id', type = 'unsigned' },
         { name = 'status', type = 'string' },
@@ -23,7 +23,7 @@ local function tube_create(opts)
         { name = 'index', type = 'unsigned' }
     }
 
-    local space = box.schema.create_space(opts.name, space_opts)
+    local space = box.schema.create_space(args.name, space_options)
     space:create_index('task_id', {
         type = 'tree',
         parts = { 'task_id' },

--- a/sharded_queue/drivers/fifottl.lua
+++ b/sharded_queue/drivers/fifottl.lua
@@ -136,13 +136,10 @@ end
 
 local function tube_create(args)
     local space_options = {}
-
     local if_not_exists = args.options.if_not_exists or true
-
     space_options.if_not_exists = if_not_exists
     space_options.temporary = args.options.temporary or false
     space_options.engine = args.options.engine or 'memtx'
-
     space_options.format = {
         { 'task_id',    'unsigned' },
         { 'bucket_id',  'unsigned' },

--- a/sharded_queue/drivers/fifottl.lua
+++ b/sharded_queue/drivers/fifottl.lua
@@ -106,6 +106,7 @@ local function fiber_iteration(tube_name, processed)
 
     if estimated > 0 or processed > 1000 then
         estimated = estimated > 0 and estimated or 0
+        processed = 0
         wc_wait(tube_name, estimated)
     end
 

--- a/test/create_test.lua
+++ b/test/create_test.lua
@@ -1,0 +1,78 @@
+local t = require('luatest')
+local g = t.group('create_test')
+
+local config = require('test.helper.config')
+
+g.before_all(function()
+    g.api = config.cluster:server('queue-router').net_box
+    g.storage = config.cluster:server('queue-storage-1-0').net_box
+end)
+
+for test_name, options in pairs({
+    none = {},
+    fifo = {
+        driver = 'sharded_queue.drivers.fifo',
+    },
+    fifottl = {
+        driver = 'sharded_queue.drivers.fifottl',
+    },
+}) do
+    g['test_create_tube_defauls_' .. test_name] = function()
+        local tube_name = 'creates_tube_defaults_' .. test_name .. '_test'
+            g.api:call('queue.create_tube', {
+            tube_name, options
+        })
+
+        local space = g.storage:eval(string.format([[
+            local space = box.space.%s
+            return {
+                temporary = space.temporary,
+                engine = space.engine,
+            }
+        ]], tube_name))
+        t.assert_not(space.temporary)
+        t.assert_equals(space.engine, 'memtx')
+    end
+end
+
+for test_name, options in pairs({
+    none_temporary = {
+        temporary = true,
+    },
+    none_engine = {
+        engine = 'vinyl',
+    },
+    fifo_temporary = {
+        driver = 'sharded_queue.drivers.fifo',
+        temporary = true,
+    },
+    fifo_engine = {
+        driver = 'sharded_queue.drivers.fifo',
+        engine = 'vinyl',
+    },
+    fifottl_temporary = {
+        driver = 'sharded_queue.drivers.fifottl',
+        temporary = true,
+    },
+    fifottl_engine = {
+        driver = 'sharded_queue.drivers.fifottl',
+        engine = 'vinyl',
+    },
+}) do
+    g['test_create_tube_opts' .. test_name] = function()
+        local tube_name = 'create_tube_opts_' .. test_name .. '_test'
+            g.api:call('queue.create_tube', {
+            tube_name, options
+        })
+
+        local space = g.storage:eval(string.format([[
+            local space = box.space.%s
+            return {
+                temporary = space.temporary,
+                engine = space.engine,
+            }
+        ]], tube_name))
+        t.assert_equals(space.temporary, options.temporary or false)
+        t.assert_equals(space.engine, options.engine or 'memtx')
+    end
+end


### PR DESCRIPTION
**bugfix: pass create_tube options to 'fifo' driver**

The fifo driver did not apply `temporary` and `engine` options
before the patch.

**bugfix: fifottl yield every time**

After 1000 processed tuples an iteration fiber yields after each
processed tuple. The problem was fixed by resetting a counter of
processed tuples without yield.