### PR TITLE
internal: unify args and options passing

### DIFF
--- a/test/simple_test.lua
+++ b/test/simple_test.lua
@@ -82,7 +82,7 @@ g.test_take_with_options = function()
     })
     local options, timeout, data = {}, 1, 'data'
 
-    for _, take_args in pairs({{}, {timeout}, {timeout, options}, {box.NULL, options}, {timeout, box.NULL}}) do
+    for _, take_args in pairs({{}, {timeout}, {timeout, options}, {box.NULL, options}}) do
         g.queue_conn:call(utils.shape_cmd(tube_name, 'put'), { data })
         local task = g.queue_conn:call(utils.shape_cmd(tube_name, 'take'), take_args)
         t.assert_equals(task[utils.index.data], data)

--- a/test/storage_test.lua
+++ b/test/storage_test.lua
@@ -1,7 +1,6 @@
 #!/usr/bin/env tarantool
 
 local t = require('luatest')
-local log = require('log')  -- luacheck: ignore
 local g = t.group('storage')
 
 local storage = require('sharded_queue.storage')


### PR DESCRIPTION
This patch unifies the setup of args and args.options for driver
methods in the following way:

* Values for args[key] should be set up through an API call.
* Values for args.options[key] should be set up via a global
  tube configuration.

Driver code should prefer args[key] values instead of args.options[key].

Current driver implementations are not affected by the code.

Closes https://github.com/tarantool/sharded-queue/issues/44
Closes https://github.com/tarantool/sharded-queue/pull/47