### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+## 0.1.0 - 2023-06-16
+
+The first release provides cartridge roles that implement a distributed
+queue API, which is compatible with the
+[Tarantool queue](https://github.com/tarantool/queue) module.

--- a/sharded_queue/version.lua
+++ b/sharded_queue/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '0.0.0'
+return '0.1.0'


### PR DESCRIPTION
## Overview

The first release provides cartridge roles that implement a distributed queue API, which is compatible with the Tarantool queue module.