### PR TITLE
changelog: add more release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 0.1.0 - 2023-06-16
 
 The first release provides cartridge roles that implement a distributed
-queue API, which is compatible with the
+message broker API, which is compatible with the
 [Tarantool queue](https://github.com/tarantool/queue) module.
+
+Please note that `sharded-queue` is not actually a queue, it implements a
+message broker. The order of task identifiers is not guaranteed between
+different shards (over the whole cluster).
+
+### Added
+
+- A Cartridge role for storages - `sharded_queue.storage`.
+- A Cartridge role for api calls from a Cartridge application - `shareded_queue.api`.
+- `fifo` API compatible driver with
+  [fifor driver in queue module](https://github.com/tarantool/queue/#fifo---a-simple-queue).
+- `fifottl` API compatible driver with
+  [fifottl driver in queue module](https://github.com/tarantool/queue/#fifottl---a-simple-priority-queue-with-support-for-task-time-to-live).
+- Metrics support for the api role (#55).
+- `_VERSION` field for roles (#58).
+- Testing CI (#53).
+- Linter check on CI (#18).
+- Publish CI (#54).


### PR DESCRIPTION
## Overview

The first release provides cartridge roles that implement a distributed message broker API, which is compatible with the [Tarantool queue](https://github.com/tarantool/queue) module.

Please note that `sharded-queue` is not actually a queue, it implements a message broker. The order of task identifiers is not guaranteed between different shards (over the whole cluster).

The module is included in `tarantool/sdk`.

## New features

- A Cartridge role for storages - `sharded_queue.storage`.
- A Cartridge role for api calls from a Cartridge application - `shareded_queue.api`.
- `fifo` API compatible driver with [fifor driver in queue module](https://github.com/tarantool/queue/#fifo---a-simple-queue).
- `fifottl` API compatible driver with [fifottl driver in queue module](https://github.com/tarantool/queue/#fifottl---a-simple-priority-queue-with-support-for-task-time-to-live).
- Metrics support for the api role (#55).
  The `sharded-queue` exports two metrics:
  * `sharded_queue_calls`
  * `sharded_queue_tasks`

  Which are similar to [api.statistics() call result](https://github.com/tarantool/queue/#getting-statistics).

  The feature is enabled by default, but it could be disabled via cluster-wide config:
  ```
  tubes:
    tube_1:
      ...
    cfg:
      metrics: false
  ```
- `_VERSION` field for roles (#58).

## Other

- Testing CI (#53).
- Linter check on CI (#18).
- Publish CI (#54).