### PR TITLE
fifottl: fix release/bury next_event setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- A deletion of a released task after `ttr` in the `fifottl` driver.
+
 ## 0.1.0 - 2023-06-16
 
 The first release provides cartridge roles that implement a distributed


### PR DESCRIPTION
`take` sets up the next event time as current time + `ttr`, while `release` and `bury` do not update the next event time. This can lead to a task being deleted after `take time` + `ttr` after `release` or `bury` in the queue fiber.

To fix the issue we can copy approach from the `queue` module [[1](https://github.com/tarantool/queue/blob/481b5fbf47a7db5c504c64a688b4f8a5fc765a45/queue/abstract/driver/fifottl.lua#L348-L351)][[2](https://github.com/tarantool/queue/blob/481b5fbf47a7db5c504c64a688b4f8a5fc765a45/queue/abstract/driver/fifottl.lua#L367-L370)].

Closes #65