### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- A deletion of a released task after `ttr` in the `fifottl` driver.
+## 0.1.1 - 2023-09-06
+
+The release fixes the loss of tasks in the `fifottl` driver.
+
+### Fixed
+
+- A deletion of a released task after `ttr` in the `fifottl` driver (#65).
 
 ## 0.1.0 - 2023-06-16
 

--- a/sharded_queue/version.lua
+++ b/sharded_queue/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '0.1.0'
+return '0.1.1'


### PR DESCRIPTION
The release fixes the loss of tasks in the `fifottl` driver.

## Breaking changes

None.

## Bugfixes

* A deletion of a released task after `ttr` in the `fifottl` driver (#65).