### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## 1.0.0 - 2024-04-17
+
+The release introduces roles for Tarantool 3 and improves the module metrics.
+
+### Added
+
 - Metric `tnt_sharded_queue_router_role_stats` is a [summary][metrics-summary]
   with quantiles of `sharded_queue.api` role API calls (#71).
   The metric includes a counter of API calls and errors.

--- a/sharded_queue/version.lua
+++ b/sharded_queue/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '0.1.1'
+return '1.0.0'


### PR DESCRIPTION
## Overview

The release introduces roles for Tarantool 3 and improves the module metrics.

## Breaking changes

* Metric `sharded_queue_calls` renamed to `tnt_sharded_queue_api_statistics_calls_total` (#71).
  The metric now has labels in the format `{name = "tube_name", state = "call_type"}` instead of `{name = "tube_name", status = "call_type"}`.
* Metric `sharded_queue_tasks` renamed to `tnt_sharded_queue_api_statistics_tasks` (#71).
  The metric now has labels in the format `{name = "tube_name", state = "task_state"}` instead of `{name = "tube_name", status = "task_state"}`.
* The dependency `cartridge` is removed from the `rockspec` since the module does not require it to work with Tarantool 3 (#68).

## New features

* Role `roles.sharded-queue-router` for Tarantool 3 (#68).
* Role `roles.sharded-queue-storage` for Tarantool 3 (#68).
* Metric `tnt_sharded_queue_api_role_stats` is a summary with quantiles of `sharded_queue.api` role API calls (#71). The metric includes a counter of API calls and errors.
  The metric contains labels in the following format:
  `{name = "tube_name", method = "api_call_method", status = "ok" or "error"}`
* Metric `tnt_sharded_queue_storage_role_stats` is a summary with quantiles of `sharded_queue.storage` role API calls (#71). The metric includes a counter of API calls and errors.
  The metric contains labels in the following format:
  `{name = "tube_name", method = "api_call_method", status = "ok" or "error"}`
* Metric `tnt_sharded_queue_storage_statistics_calls_total` as an equivalent of `tnt_sharded_queue_api_statistics_calls_total` for the `sharded_queue.storage` role. (#71) Values have the same meaning as the `queue` statistics `calls` table.
  The metric contains labels in the following format:
  `{name = "tube_name", state = "call_type"}`
* Metric `tnt_sharded_queue_storage_statistics_tasks` as an equivalent of `tnt_sharded_queue_api_statistics_tasks` for the `sharded_queue.storage` role (#71). Values have the same meaning as the `queue` statistics `tasks` table.
  The metric contains labels in the following format:
  `{name = "tube_name", state = "task_state"}`

## Bugfixes

* Data race with fifo driver for put()/take() methods with vinyl engine (#64).