### PR TITLE
ci: actualize CI/CD jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   version-check:
     # We need this job to run only on push with tag.
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check module version for api
         uses: tarantool/actions/check-module-version@master
@@ -22,7 +22,7 @@ jobs:
 
   publish-rockspec-scm-1:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 
@@ -40,7 +40,7 @@ jobs:
 
   publish-rockspec-tag:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         tarantool:
-          - '2.8'
-          - '2.10'
-        cartridge: [true]
+          - '3.2'
+          - '3.4'
+          - 'master'
+        cartridge: [false]
         coveralls: [false]
         metrics: [false]
         include:
@@ -28,19 +29,15 @@ jobs:
             cartridge: true
             coveralls: true
             metrics: true
-          - tarantool: 'master'
-            cartridge: false
-            coveralls: false
-            metrics: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone the module
         uses: actions/checkout@v3
 
       - name: Setup tt
         run: |
-          curl -L https://tarantool.io/release/2/installer.sh | sudo bash
+          curl -L https://tarantool.io/release/3/installer.sh | sudo bash
           sudo apt install -y tt
 
       - name: Install tarantool ${{ matrix.tarantool }}


### PR DESCRIPTION
Ubuntu image changed to latest tag since ubuntu 20.04 image deprecation[1] broke CI/CD jobs.

Remove EOL tarantool versions. The latest two versions of tarantool 3 was added.

1. https://github.com/actions/runner-images/issues/11101